### PR TITLE
Add framework and instructions for building debian buster package

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -1,0 +1,4 @@
+This repo contains docker images and require scripting for generating dynamic shared modules against a debian package. For example to build a shared object that can be used on the latest nginx available in debian buster:
+
+docker build -f ./Dockerfile-buster -t nginx-dogstatsd-builder:buster .
+docker run -v $(pwd):/opt/nginx-dogstatsd nginx-dogstatsd-builder:buster

--- a/Dockerfile-buster
+++ b/Dockerfile-buster
@@ -1,0 +1,11 @@
+FROM debian:buster
+
+RUN set -ex \
+  && sed 's/deb /deb-src /' /etc/apt/sources.list >> /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y build-essential dpkg-dev \
+  && apt-get build-dep -y nginx-light
+
+ADD . /opt/nginx-dogstatsd
+
+CMD /opt/nginx-dogstatsd/debian-build.sh

--- a/debian-build.sh
+++ b/debian-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+apt-get update
+apt-get source nginx-light
+tar xvf nginx_*.debian.tar.xz
+
+echo -e "print-%:\n\t@echo" '$($*)' > printvar.mk
+configure_flags=$(make -f printvar.mk -f debian/rules print-light_configure_flags)
+
+cd nginx-*/
+./configure $(configure_flags) --add-dynamic-module=/opt/nginx-dogstatsd/
+make modules
+
+mv objs/ngx_http_dogstatsd_module.so /opt/nginx-dogstatsd/


### PR DESCRIPTION
This adds a script and Dockerfile which can be used to generate a valid dynamic nginx module for this repo based on the latest package available in debian. This results in a compatible module that can be dropped into `/usr/lib/nginx/modules` and loaded within nginx (for the same debian package version). 